### PR TITLE
Low-Battery Cutoff Threshold

### DIFF
--- a/Firmware/OWL_Boron_Maxbotix_MB7092_cm/src/OWL_Boron_Maxbotix_MB7092_cm.cpp
+++ b/Firmware/OWL_Boron_Maxbotix_MB7092_cm/src/OWL_Boron_Maxbotix_MB7092_cm.cpp
@@ -78,7 +78,7 @@ SystemSleepConfiguration config;
 
 // Various timing constants
 unsigned long MAX_TIME_TO_PUBLISH_MS = 900000; // Only stay awake for this time trying to connect to the cloud and publish.
-const unsigned long TIME_AFTER_PUBLISH_MS = 120000; // After publish, wait 2 minutes for data to go out
+const unsigned long TIME_AFTER_PUBLISH_MS = 4000; // After publish, wait 2 minutes for data to go out
 
 // ***** IMPORTANT!!!
  //If SECONDS_BETWEEN_MEASUREMENTS < 600, must use 

--- a/Firmware/OWL_Boron_Maxbotix_MB7092_cm/src/OWL_Boron_Maxbotix_MB7092_cm.cpp
+++ b/Firmware/OWL_Boron_Maxbotix_MB7092_cm/src/OWL_Boron_Maxbotix_MB7092_cm.cpp
@@ -67,12 +67,18 @@ int outOfMemory = -1;
 void outOfMemoryHandler(system_event_t event, int param);
 const std::chrono::milliseconds freeMemoryLogTime = 5min;
 
+// Battery Monitoring thresholds
+const float LOW_VOLTAGE_CUTOFF = 3.30;     // Enter recovery mode
+const float LOW_VOLTAGE_RESUME = 3.50;     // Resume normal operation
+const int LOW_BATTERY_SLEEP_SECONDS = 86400;   // 24 hours
+bool lowBatteryMode = false;
+
 // Sleep configuration
 SystemSleepConfiguration config;
 
 // Various timing constants
 unsigned long MAX_TIME_TO_PUBLISH_MS = 900000; // Only stay awake for this time trying to connect to the cloud and publish.
-const unsigned long TIME_AFTER_PUBLISH_MS = 4000; // After publish, wait 4 seconds for data to go out
+const unsigned long TIME_AFTER_PUBLISH_MS = 120000; // After publish, wait 2 minutes for data to go out
 
 // ***** IMPORTANT!!!
  //If SECONDS_BETWEEN_MEASUREMENTS < 600, must use 
@@ -113,7 +119,31 @@ void loop(void) {
     Then, if PUBLISHING==1, go to PUBLISH_STATE. Else,
     go to SLEEP_STATE.
     ***/
+
+
   case DATALOG_STATE: {
+
+  // Get battery charge before datalogging to avoid any issues with low battery during datalogging
+    float cellVoltage = batteryMonitor.getVCell();
+    float stateOfCharge = batteryMonitor.getSoC();
+
+    Log.info("Battery = %.2f V", cellVoltage);
+
+    // Enter low battery mode
+    if (cellVoltage <= LOW_VOLTAGE_CUTOFF) {
+    lowBatteryMode = true;
+    }
+
+    // Leave low battery mode only after recovering
+    if (lowBatteryMode && cellVoltage >= LOW_VOLTAGE_RESUME) {
+        lowBatteryMode = false;
+    }
+
+    if (lowBatteryMode) {
+        Log.info("Battery too low. Sleeping for one day.");
+        state = SLEEP_STATE;
+        break;
+    }
 
     if (outOfMemory >= 0) {
         // An out of memory condition occurred - reset device.
@@ -163,9 +193,6 @@ void loop(void) {
     hour_of_day_UTC = Time.hour(); // Get hour of day (UTC) for deciding timeout
     millis_now = millis();
 
-    // Get battery charge if Boron provides it
-    float cellVoltage = batteryMonitor.getVCell();
-    float stateOfCharge = batteryMonitor.getSoC();
 
     snprintf(data, sizeof(data), "%li,%.5f,%.02f,%.02f", //,%.5f,%.5f,%.5f,%.5f,%.5f,%.02f,%.02f",
       real_time, // if it takes a while to connect, this time could be offset from sensor recording
@@ -268,8 +295,15 @@ void loop(void) {
     Log.info("going to sleep");
     delay(500);
 
-    // Sleep time determination and configuration
-    int wakeInSeconds = secondsUntilNextEvent(); // Calculate how long to sleep 
+    // Sleep time determination and configuration based on battery level. If low battery, sleep for 24 hours. Otherwise, sleep until next measurement time.
+    int wakeInSeconds;
+
+    if (lowBatteryMode) {
+        wakeInSeconds = LOW_BATTERY_SLEEP_SECONDS;
+    }
+    else {
+    wakeInSeconds = secondsUntilNextEvent();
+    }
 
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
       .gpio(D2, FALLING)


### PR DESCRIPTION
Addressing Issue #94 

In lines 70–74, I added two battery-voltage thresholds: a low-voltage cutoff (3.3 V), below which the Boron enters a low-battery "recovery mode", and a resume threshold (3.5 V), above which normal cycling continues. The gap between these thresholds may prevent the Boron from repeatedly waking and sleeping if the battery voltage hovers near the cutoff. 

Line 73 defines the sleep time for recovery, which is currently set to 24 hours. After this period, the Boron wakes, checks the battery voltage, and either returns to sleep or resumes normal cycling if the battery has passed the resume threshold of 3.5V.

Lines 126–147 implements this logic at the beginning of the DATALOG_STATE.

Lines 298–306 modifies the SLEEP_STATE so that, when in low-battery recovery mode, the Boron sleeps for the 24-hour recovery interval instead of the normal measurement interval. 

I chose these thresholds based on waterLevel_0003 data. I think we could have more conservative thresholds with a cutoff of 3.7 and a resume at 3.9 but I am happy to hear your thoughts based on what you are seeing too. 